### PR TITLE
Revert "Bump blue-build/github-action from 1.0.2 to 1.2.0"

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
     steps:
        # the build is fully handled by the reusable github action
       - name: Build Custom Image
-        uses: blue-build/github-action@v1.2.0
+        uses: blue-build/github-action@v1.0.2
         with:
           recipe: ${{ matrix.recipe }}
           cosign_private_key: ${{ secrets.SIGNING_SECRET }}


### PR DESCRIPTION
Reverts johnr14/ublue-kde-workstation#3

New version doesn't allow rawhide !